### PR TITLE
Add libpq-dev to prerequisites.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,3 +55,4 @@ zammad_system_prerequisites_packages:
   - gawk
   - libimlib2
   - libimlib2-dev
+  - libpq-dev


### PR DESCRIPTION
As per [this article](https://community.zammad.org/t/install-tips-as-of-december-2018-zammad-2-8/1519), Zammad needs `libpq-dev` when trying to use a PostgreSQL database which is hosted on another server. 

I had the issue and installing it fixed it. 